### PR TITLE
Typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
         <div class="flex-col flex-shrink-0 px-4 py-4">
           <h1 class="text-3xl pb-4">Typography</h1>
           <div class="container">
-
+            <p>HELLO I AM HERE.</p>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,28 @@
         <div class="flex-col flex-shrink-0 px-4 py-4">
           <h1 class="text-3xl pb-4">Typography</h1>
           <div class="container">
-            <p>HELLO I AM HERE.</p>
+            <h2 class="text-2xl pb-4">This is Overpass</h2>
+            <p>Inspired by the typeface used in road signage all around America, Overpass represents the UX Wizards’ ever expanding reach. 
+            </p><br>
+            <a href="https://fonts.google.com/specimen/overpass ">↳ Download Overpass</a>
+            <h2 class="text-2xl pb-4 pt-16">Scale</h2>
+            <p>The scale is absolute, but the font-weight and styling are simply guidelines. Headings can be selected from the scale as necessary, but hierarchy must be consistent across each medium. 
+              This scale works best with 12, 14, or 16 as the base font-size (1em = 16px). The samples below show the scale with a base of 16px. 
+            </p>
+            <h2 class="text-2xl pb-4 pt-16">Guidelines</h2>
+            <h3 class="text-xl pb-4 pt-8">Leading</h3>
+            <p>Ideally, body type should have a line-height of at least 125% of the font size. For example, a paragraph of font size 14 with a line-height of 24.
+            </p>
+            <h3 class="text-xl pb-4 pt-8">Character length</h3>
+            <p>Limit line length of body text between 50-75 characters for better readability.
+            </p>
+            <h3 class="text-xl pb-4 pt-8">Accessibility</h3>
+            <p>Accessibility comes first. Type colors should meet WCAG 2.0 standard for contrast. 
+              ↳ Color contrast guidelines
+            </p>
+            <h2 class="text-2xl pb-4 pt-16">Usage</h2>
+            <p>Example</p>
+            <h2 class="text-2xl pb-4 pt-16" pt-16>CSS</h2>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <meta content="utf-8" http-equiv="encoding">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Overpass:wght@900&display=swap" rel="stylesheet">
+    <link href="<link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;700;800;900&display=swap" rel="stylesheet">
     <link href="https://unpkg.com/prismjs@1.23.0/themes/prism.css" rel="stylesheet" />
     <script src="https://unpkg.com/prismjs@1.23.0/components/prism-core.min.js"></script>
     <script src="https://unpkg.com/prismjs@1.23.0/plugins/autoloader/prism-autoloader.min.js"></script>
@@ -86,7 +87,7 @@
           </div>
         </div>
 
-        <div class="flex-col flex-shrink-0 px-4 py-4">
+        <div class="flex-col flex-shrink-0 px-4 py-4" style="font-family: Overpass;">
           <h1 class="text-3xl pb-4">Typography</h1>
           <div class="container">
             <h2 class="text-2xl pb-4">This is Overpass</h2>
@@ -97,6 +98,72 @@
             <p>The scale is absolute, but the font-weight and styling are simply guidelines. Headings can be selected from the scale as necessary, but hierarchy must be consistent across each medium. 
               This scale works best with 12, 14, or 16 as the base font-size (1em = 16px). The samples below show the scale with a base of 16px. 
             </p>
+            <table class="w-full text-left table-auto my-4">
+              <thead>
+                <tr>
+                  <th class="px-4 py-2">Style</th>
+                  <th class="px-4 py-2">Size (em)</th>
+                  <th class="px-4 py-2">Size (px)</th>
+                  <th class="px-4 py-2">Sample</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="px-4 py-2">Extra Bold</td>
+                  <td class="px-4 py-2">3.375em</td>
+                  <td class="px-4 py-2">54px</td>
+                  <td class="px-4 py-2 font-extrabold" style="font-size: 3.375em; line-height: 1;">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Extra Bold</td>
+                  <td class="px-4 py-2">2.25em</td>
+                  <td class="px-4 py-2">36px</td>
+                  <td class="px-4 py-2 font-extrabold text-4xl">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Bold</td>
+                  <td class="px-4 py-2">1.75</td>
+                  <td class="px-4 py-2">27px</td>
+                  <td class="px-4 py-2 font-bold" style="font-size: 1.75em; line-height: 1;">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Regular</td>
+                  <td class="px-4 py-2">1.5em</td>
+                  <td class="px-4 py-2">24px</td>
+                  <td class="px-4 py-2 text-2xl">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Regular</td>
+                  <td class="px-4 py-2">1.313em</td>
+                  <td class="px-4 py-2">21px</td>
+                  <td class="px-4 py-2" style="font-size: 1.313em">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Bold</td>
+                  <td class="px-4 py-2">1em</td>
+                  <td class="px-4 py-2">16px</td>
+                  <td class="px-4 py-2 font-bold">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Regular</td>
+                  <td class="px-4 py-2">1em</td>
+                  <td class="px-4 py-2">16px</td>
+                  <td class="px-4 py-2">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Regular</td>
+                  <td class="px-4 py-2">0.875em</td>
+                  <td class="px-4 py-2">14px</td>
+                  <td class="px-4 py-2 text-sm">Design meets magic</td>
+                </tr>
+                <tr>
+                  <td class="px-4 py-2">Regular</td>
+                  <td class="px-4 py-2">0.75em</td>
+                  <td class="px-4 py-2">12px</td>
+                  <td class="px-4 py-2 uppercase text-xs">Design meets magic</td>
+                </tr>
+              </tbody>
+            </table>
             <h2 class="text-2xl pb-4 pt-16">Guidelines</h2>
             <h3 class="text-xl pb-4 pt-8">Leading</h3>
             <p>Ideally, body type should have a line-height of at least 125% of the font size. For example, a paragraph of font size 14 with a line-height of 24.

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
             </p>
             <h2 class="text-2xl pb-4 pt-16">Usage</h2>
             <p>Example</p>
-            <h2 class="text-2xl pb-4 pt-16" pt-16>CSS</h2>
+            <h2 class="text-2xl pb-4 pt-16">CSS</h2>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
         <div class="flex-col flex-shrink-0 px-4 py-4">
           <h1 class="text-3xl pb-4">Contributors</h1>
           <div class="container">
-            <p>Sup dog!</p>
+            <p>Sup dogzzzz!</p>
 
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta content="utf-8" http-equiv="encoding">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
-    <link href="<link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;700;800;900&display=swap" rel="stylesheet">
     <link href="https://unpkg.com/prismjs@1.23.0/themes/prism.css" rel="stylesheet" />
     <script src="https://unpkg.com/prismjs@1.23.0/components/prism-core.min.js"></script>


### PR DESCRIPTION
Outline for typography section with the type scale table. 

Notes:
Tailwind font-sizes don't line up with some of the brand guideline font-sizes. 

TODO: add our own styles to tailwind defaults if we want them to match. 
TODO: add a character length limit main content 
