### PR TITLE
 Typography Page Update

### DIFF
--- a/UXWTypography.js
+++ b/UXWTypography.js
@@ -145,13 +145,7 @@ function UXWTypography(props) {
           
 
 
-          <t-table
-  :headers="['Name', 'Email', 'Age', 'Sales']"
-  :data="[
-    ['Alfonso Bribiesca', 'alfonso@vexilo.com', '31', '$9,999.00'],
-    ['Saida Redondo', 'saida@gmail.com', 27, '$124.00'],
-  ]"
-></t-table>
+          
           
 
       </UXWSubsection>

--- a/UXWTypography.js
+++ b/UXWTypography.js
@@ -1,3 +1,5 @@
+
+
 const { Card, CardActions, CardContent, Button} = window['MaterialUI'];
 
 function UXWTypography(props) {
@@ -6,20 +8,31 @@ function UXWTypography(props) {
       <UXWSubsection anchor="typography--font" title="Font">
         <p className="max-w-prose">Inspired by the typeface used in road signage all around America, Overpass represents the UX Wizards’ ever expanding reach.
         </p>
-        <a href="https://fonts.google.com/specimen/Overpass">↳ Download Overpass</a>
+        <a href="https://fonts.google.com/specimen/Overpass" target="_blank">↳ Download Overpass</a>
       </UXWSubsection>
+
       <UXWSubsection anchor="typography--scale" title="Scale">
-        <p className="max-w-prose">The scale is absolute, but the font-weight and styling are simply guidelines. Headings can be selected from the scale as necessary, but hierarchy must be consistent across each medium.
-          This scale works best with 12, 14, or 16 as the base font-size (1em = 16px). The samples below show the scale with a base of 16px.
+        <h3 className="text-xl pb-4">How to Use It</h3>
+          <div className="flex flex-row pb-4">
+            <div className="box w-20 rounded-full uxw-bg-steel-1 text-center mr-4">BASES</div>
+              <p> 16px |14px |12px </p>
+            </div>
+
+        <p className="max-w-prose">
+          This scale works best with 12, 14, or 16 as the base font-size (1em = 16px).
+          The scale is absolute, but the font-weight and styling are simply guidelines. 
+          Headings can be selected from the scale as necessary, but hierarchy must be consistent across each medium.
+          The samples below show the scale with a base of 16px.
         </p>
-        <table className="uxw-font-sans w-full text-left table-auto my-4">
+
+        <table className="uxw-font-sans w-full text-left table-auto my-4 bg-gray-100">
           <thead>
-            <tr>
+            <tr className="bg-gray-200 rounded-t-lg">
               <th className="px-4 py-2">Style</th>
               <th className="px-4 py-2">Size (em)</th>
               <th className="px-4 py-2">Size (px)</th>
               <th className="px-4 py-2">Sample</th>
-            </tr>
+             </tr>
           </thead>
           <tbody>
             <tr>
@@ -90,50 +103,66 @@ function UXWTypography(props) {
             </tr>
           </tbody>
         </table>
+
+
+        
       </UXWSubsection>
+
       <UXWSubsection anchor="typography--guidelines" title="Guidelines">
-        <h3 className="text-xl pb-4 pt-8">Leading</h3>
+        <h3 className="text-xl pb-4">Leading</h3>
         <p className="max-w-prose">Ideally, body type should have a line-height of at least 125% of the font size. For example, a paragraph of font size 14 with a line-height of 24.
         </p>
-        <h3 className="text-xl pb-4 pt-8">Character length</h3>
+        <h3 className="text-xl pb-4 pt-4">Character length</h3>
         <p className="max-w-prose">Limit line length of body text between 50-75 characters for better readability.
         </p>
-        <h3 className="text-xl pb-4 pt-8">Accessibility</h3>
+        <h3 className="text-xl pb-4 pt-4">Accessibility</h3>
         <p className="max-w-prose">Accessibility comes first. Type colors should meet WCAG 2.0 standard for contrast.
           ↳ Color contrast guidelines
         </p>
       </UXWSubsection>
-      {/*<UXWSubsection anchor="typography--usage" title="Usage">
+
+
+
+      <UXWSubsection anchor="typography--usage" title="Usage">
         <p className="max-w-prose">Example</p>
-          <div class="grid grid-cols-2">
-            <div>
-              <div className="h-16 px-4 py-2 uppercase text-xs" style={{fontFamily: "Overpass"}}>
-                H1
-              </div>
-              <div className="h-16 px-4 py-2 uppercase text-xs" style={{fontFamily: "Overpass"}}>
-                H2
-              </div>
-              <div className="h-16 px-4 py-2 uppercase text-xs" style={{fontFamily: "Overpass"}}>
-                paragraph
-              </div>
-            </div>
-            <div>
-              <div className="h-16 font-extrabold" style={{fontFamily: "Overpass", fontSize: "3.375em"}}>
-                Design Meets Magic
-              </div>
 
-              <div className="h-16 p-2 font-bold" style={{fontFamily: "Overpass", fontSize: "1.75em", lineHeight: 1}}>
-                The UX Wizards are here.
-              </div>
+        <div className="flex flex-row">
+          <div className="flex flex-col"> 
+            <p className="box w-20 m-4 rounded-full uxw-bg-steel-1 text-center"> H1 </p>
+            <p className="box w-20 m-4 rounded-full uxw-bg-steel-1 text-center"> H2 </p>
+            <div className="box w-32 m-4 rounded-full uxw-bg-steel-1 text-center mr-4">PARAGRAPH </div>
+            <div className="box w-28 m-4 rounded-full uxw-bg-steel-1 text-center  mr-4">BUTTON </div>
+          </div>
+          <div className="flex flex-col">
+            <p class="m-2 uxw-text-display-1">Design Meets Magic</p>
+            <p class="m-2 uxw-text-display-2">The UX Wizards are here. </p>
+            <p class="m-2">We're looking for designers of all levels to come on board. Ready to work your wizardly? </p>
+            <a className="m-2 w-56 text-center text-white py-4 px-4 from-indigo-600 to-indigo-900 bg-gradient-to-r rounded-md uppercase tracking-widest font-light hover:shadow-2xl transition duration-500 ease-in-out hover:bg-opacity-40">JOIN OUR TEAM</a>
 
-              <div className="h-16 p-2" style={{fontFamily: "Overpass"}}>We’re looking for designers of all levels to com on board. Ready to work your wizardry?
-              </div>
-            </div>
-        </div>
-      </UXWSubsection>*/}
+          </div>
+          </div>
+
+          
+
+
+          <t-table
+  :headers="['Name', 'Email', 'Age', 'Sales']"
+  :data="[
+    ['Alfonso Bribiesca', 'alfonso@vexilo.com', '31', '$9,999.00'],
+    ['Saida Redondo', 'saida@gmail.com', 27, '$124.00'],
+  ]"
+></t-table>
+          
+
+      </UXWSubsection>
     </div>
+
+
   );
 }
+ 
+      
+
 
   function SimpleCard() {
 
@@ -152,6 +181,10 @@ function UXWTypography(props) {
       </Card>
     );
   }
+
+  
+
+
 
  /* <div class="flex items-center">
         <div className="flex-initial space-x-4">

--- a/uxw.css
+++ b/uxw.css
@@ -32,4 +32,9 @@ p {
   font-size: 1em;
 }
 
+tr:nth-child(even) {
+ 
+  background-color: var(--uxw-color-merlins-beard-1);
+}
+
 /* Logos and Icons */


### PR DESCRIPTION
Updates that had been made:
- Fix the spacing for Guidelines
- Show the baselines: 12, 14, or 16
- Example Typography
- Link to download Overpass should open a new tab.
- Zebra stripe the table.